### PR TITLE
fix: redis 4 adapter not an integer or out of range error

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -125,7 +125,7 @@ export function redisCacheAdapter(redisCache: RedisLikeCache): Cache {
         JSON.stringify(value),
         ttl > 0 && ttl < Infinity && typeof createdTime === 'number'
           ? {
-              EXAT: (ttl + createdTime) / 1000,
+              EXAT: Math.ceil((ttl + createdTime) / 1000),
             }
           : undefined,
       );

--- a/src/cachified.spec.ts
+++ b/src/cachified.spec.ts
@@ -1171,7 +1171,7 @@ describe('cachified', () => {
         metadata: { ttl: 1, swr: 0, createdTime: 0 },
         value: 'FOUR',
       }),
-      { EXAT: 0.001 },
+      { EXAT: 1 },
     );
 
     await cache.set('lel', undefined as any);


### PR DESCRIPTION
In this PR

- Added `Math.ceil()` to the redisAdapter EXAT parameter to prevent `ERR value is not an integer or out of range` errors with real redis instances
- Updated the redis 4 related test.

Closes #17 

Please note that you can entirely disregard my PR if you have a better solution. If I had time, I would have changed the tests in a way, that `Date.now()` would return a more real-like timestamp, but that would also require me to update all other tests.