### PR TITLE
Context for getFreshValue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,13 @@ interface CachifiedOptions<Value> {
    *
    * Can be async and must return fresh value or throw.
    *
-   * @type {function(): Promise | Value} Required
+   * context looks like this:
+   *  - context.metadata.ttl?: number
+   *  - context.metadata.swr?: number
+   *  - context.metadata.createdTime: number
+   *  - context.background: boolean
+   *
+   * @type {function(context: GetFreshValueContext): Promise | Value} Required
    */
   getFreshValue: GetFreshValue<Value>;
   /**

--- a/src/cachified.spec.ts
+++ b/src/cachified.spec.ts
@@ -731,16 +731,40 @@ describe('cachified', () => {
         getFreshValue,
       });
 
-    expect(
-      await getValue(({ metadata }) => {
-        metadata.ttl = 10;
-        return 'ONE';
-      }),
-    ).toBe('ONE');
+    const firstCallMetaDataD = new Deferred<CacheMetadata>();
+
+    const d = new Deferred<string>();
+    const p1 = getValue(({ metadata }) => {
+      metadata.ttl = 10;
+      // Don't do this at home kids...
+      firstCallMetaDataD.resolve(metadata);
+      return d.promise;
+    });
+
+    const metadata = await firstCallMetaDataD.promise;
 
     currentTime = 6;
+    // First call is still ongoing and initial ttl is over, still we exceeded
+    // the ttl in the call so this should not be called ever
+    const p2 = getValue(() => {
+      throw new Error('Never');
+    });
 
-    expect(await getValue(() => 'TWO')).toBe('ONE');
+    // Further exceeding the ttl and resolving first call
+    metadata!.ttl = 15;
+    d.resolve('ONE');
+
+    expect(await p1).toBe('ONE');
+    expect(await p2).toBe('ONE');
+
+    // now proceed to time between first and second modification of ttl
+    currentTime = 13;
+    // we still get the cached value from first call
+    expect(
+      await getValue(() => {
+        throw new Error('Never2');
+      }),
+    ).toBe('ONE');
   });
 
   it('resolves earlier pending values with faster responses from later calls', async () => {

--- a/src/cachified.spec.ts
+++ b/src/cachified.spec.ts
@@ -16,6 +16,7 @@ import {
   redisCacheAdapter,
   RedisLikeCache,
   totalTtl,
+  GetFreshValue,
 } from './index';
 import { Deferred } from './createBatch';
 import { logKey } from './assertCacheEntry';
@@ -803,7 +804,15 @@ describe('cachified', () => {
 
     // next call gets the revalidated response
     expect(await getValue()).toBe('value-1');
+
+    const getFreshValueCalls = getFreshValue.mock.calls as any as Parameters<
+      GetFreshValue<string>
+    >[];
     expect(getFreshValue).toHaveBeenCalledTimes(2);
+
+    // Does pass info if it's a stale while revalidate call
+    expect(getFreshValueCalls[0][0].background).toBe(false);
+    expect(getFreshValueCalls[1][0].background).toBe(true);
 
     // Does not deliver stale cache when swr is exceeded
     currentTime = 30;

--- a/src/cachified.spec.ts
+++ b/src/cachified.spec.ts
@@ -716,6 +716,32 @@ describe('cachified', () => {
     expect(await pValue2).toBe('TWO');
   });
 
+  it('supports extending ttl during getFreshValue operation', async () => {
+    const cache = new Map<string, CacheEntry>();
+    const reporter = createReporter();
+    const getValue = (
+      getFreshValue: CachifiedOptions<string>['getFreshValue'],
+    ) =>
+      cachified({
+        cache,
+        ttl: 5,
+        key: 'test',
+        reporter,
+        getFreshValue,
+      });
+
+    expect(
+      await getValue(({ metadata }) => {
+        metadata.ttl = 10;
+        return 'ONE';
+      }),
+    ).toBe('ONE');
+
+    currentTime = 6;
+
+    expect(await getValue(() => 'TWO')).toBe('ONE');
+  });
+
   it('resolves earlier pending values with faster responses from later calls', async () => {
     const cache = new Map<string, CacheEntry>();
     const getValue = (

--- a/src/common.ts
+++ b/src/common.ts
@@ -26,9 +26,12 @@ export interface Cache {
   delete: (key: string) => unknown | Promise<unknown>;
 }
 
+interface GetFreshValueContext {
+  metadata: CacheMetadata;
+}
 export const HANDLE = Symbol();
 export type GetFreshValue<Value> = {
-  (): Promise<Value> | Value;
+  (context: GetFreshValueContext): Promise<Value> | Value;
   [HANDLE]?: () => void;
 };
 export const MIGRATED = Symbol();
@@ -72,7 +75,7 @@ export interface CachifiedOptions<Value> {
    *
    * Can be async and must return fresh value or throw.
    *
-   * @type {function(): Promise | Value} Required
+   * @type {function(context): Promise | Value} Required
    */
   getFreshValue: GetFreshValue<Value>;
   /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,6 +28,7 @@ export interface Cache {
 
 interface GetFreshValueContext {
   metadata: CacheMetadata;
+  background: boolean;
 }
 export const HANDLE = Symbol();
 export type GetFreshValue<Value> = {
@@ -75,7 +76,13 @@ export interface CachifiedOptions<Value> {
    *
    * Can be async and must return fresh value or throw.
    *
-   * @type {function(context): Promise | Value} Required
+   * context looks like this:
+   *  - context.metadata.ttl?: number
+   *  - context.metadata.swr?: number
+   *  - context.metadata.createdTime: number
+   *  - context.background: boolean
+   *
+   * @type {function(context: GetFreshValueContext): Promise | Value} Required
    */
   getFreshValue: GetFreshValue<Value>;
   /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -27,8 +27,8 @@ export interface Cache {
 }
 
 interface GetFreshValueContext {
-  metadata: CacheMetadata;
-  background: boolean;
+  readonly metadata: CacheMetadata;
+  readonly background: boolean;
 }
 export const HANDLE = Symbol();
 export type GetFreshValue<Value> = {

--- a/src/getCachedValue.ts
+++ b/src/getCachedValue.ts
@@ -58,6 +58,9 @@ export async function getCachedValue<Value>(
         void cachified({
           ...context,
           reporter: () => () => {},
+          getFreshValue({ metadata }) {
+            return context.getFreshValue({ metadata, background: true });
+          },
           forceFresh: true,
           fallbackToCache: false,
         })

--- a/src/getFreshValue.ts
+++ b/src/getFreshValue.ts
@@ -14,7 +14,7 @@ export async function getFreshValue<Value>(
   let value: unknown;
   try {
     report({ name: 'getFreshValueStart' });
-    const freshValue = await getFreshValue();
+    const freshValue = await getFreshValue({ metadata: context.metadata });
     value = freshValue;
     report({ name: 'getFreshValueSuccess', value: freshValue });
   } catch (error) {

--- a/src/getFreshValue.ts
+++ b/src/getFreshValue.ts
@@ -14,7 +14,10 @@ export async function getFreshValue<Value>(
   let value: unknown;
   try {
     report({ name: 'getFreshValueStart' });
-    const freshValue = await getFreshValue({ metadata: context.metadata });
+    const freshValue = await getFreshValue({
+      metadata: context.metadata,
+      background: false,
+    });
     value = freshValue;
     report({ name: 'getFreshValueSuccess', value: freshValue });
   } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export type {
   CacheEntry,
   CacheMetadata,
   Context,
+  GetFreshValue,
 } from './common';
 export { staleWhileRevalidate, totalTtl } from './common';
 export * from './reporter';


### PR DESCRIPTION
Pre-released as `cachified@3.1.0-context-info.1`

Introduces context which is passed to `getFreshValue`

context looks like this:
  - context.metadata.ttl?: number
  - context.metadata.swr?: number
  - context.metadata.createdTime: number
  - context.background: boolean
  
 